### PR TITLE
Add Markdown UI and deletion options

### DIFF
--- a/BedtimeStories/Services/StoryGenerationService.swift
+++ b/BedtimeStories/Services/StoryGenerationService.swift
@@ -37,11 +37,12 @@ class StoryGenerationService: ObservableObject {
     private func buildPrompt(duration: ReadingDuration, description: String?, favoriteCharacters: String?) -> String {
         var prompt = """
         Generate a bedtime story that is approximately \(duration.rawValue) minutes long when read aloud.
-        
+
         Requirements:
         - The story should be calming and suitable for bedtime
         - Include gentle, peaceful themes
         - End with a soothing conclusion that helps children fall asleep
+        - Provide the story content formatted as Markdown
         """
         
         if let description = description, !description.isEmpty {

--- a/BedtimeStories/Views/CreateStoryView.swift
+++ b/BedtimeStories/Views/CreateStoryView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import FirebaseVertexAI
+import MarkdownUI
 
 struct CreateStoryView: View {
     @Environment(\.dismiss) private var dismiss
@@ -51,8 +52,7 @@ struct CreateStoryView: View {
                 
                 if let content = generatedContent {
                     Section("Generated Story") {
-                        Text(content)
-                            .font(.body)
+                        Markdown(content)
                     }
                 }
             }
@@ -77,7 +77,7 @@ struct CreateStoryView: View {
                         onSave(story)
                         dismiss()
                     }
-                    .disabled(title.isEmpty)
+                    .disabled(title.isEmpty || (generatedContent?.isEmpty ?? true))
                 }
             }
             .alert("Error", isPresented: $showError) {

--- a/BedtimeStories/Views/StoryDetailView.swift
+++ b/BedtimeStories/Views/StoryDetailView.swift
@@ -1,7 +1,12 @@
 import SwiftUI
+import MarkdownUI
 
 struct StoryDetailView: View {
     let story: Story
+    let onDelete: (Story) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var showingDeleteAlert = false
     
     var body: some View {
         ScrollView {
@@ -36,7 +41,7 @@ struct StoryDetailView: View {
                     }
                 }
                 if let content = story.content {
-                    Text(content)
+                    Markdown(content)
                 }
                 
                 Spacer()
@@ -56,5 +61,23 @@ struct StoryDetailView: View {
             .padding()
         }
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(role: .destructive) {
+                    showingDeleteAlert = true
+                } label: {
+                    Image(systemName: "trash")
+                }
+            }
+        }
+        .alert("Delete Story?", isPresented: $showingDeleteAlert) {
+            Button("Delete", role: .destructive) {
+                onDelete(story)
+                dismiss()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This action cannot be undone.")
+        }
     }
 }

--- a/BedtimeStories/Views/StoryListView.swift
+++ b/BedtimeStories/Views/StoryListView.swift
@@ -28,7 +28,14 @@ struct StoryListView: View {
                 } else {
                     List {
                         ForEach(stories) { story in
-                            NavigationLink(destination: StoryDetailView(story: story)) {
+                            NavigationLink(
+                                destination: StoryDetailView(
+                                    story: story,
+                                    onDelete: { deleted in
+                                        Task { await deleteStory(deleted) }
+                                    }
+                                )
+                            ) {
                                 StoryRowView(story: story)
                             }
                         }
@@ -96,6 +103,19 @@ struct StoryListView: View {
                     print("Error deleting story: \(error)")
                 }
             }
+        }
+    }
+
+    @MainActor
+    private func deleteStory(_ story: Story) async {
+        guard let index = stories.firstIndex(where: { $0.id == story.id }) else {
+            return
+        }
+        do {
+            try await firestoreService.deleteStory(story)
+            stories.remove(at: index)
+        } catch {
+            print("Error deleting story: \(error)")
         }
     }
 }


### PR DESCRIPTION
## Summary
- generate Markdown stories using VertexAI service
- render generated Markdown in the create and detail views
- disable saving when no Markdown story exists
- allow deleting stories from detail view

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_68418caa6efc8328bbcf2a67c8c1a18d